### PR TITLE
Fix for minikube v1.4.0-beta.0

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -9,7 +9,7 @@ cmd="$cmd $releases_path"
 
 # stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
 function sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
+  sed 'h; s/[+]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 


### PR DESCRIPTION
https://github.com/kubernetes/minikube/releases/tag/v1.4.0-beta.0

Before the patch the versions was `v1.4.0.beta.0`, when should be `v1.4.0-beta.0`

This fix it.